### PR TITLE
Add Google API headers

### DIFF
--- a/lib/src/core/client/http_client.dart
+++ b/lib/src/core/client/http_client.dart
@@ -1,9 +1,15 @@
 import 'package:http/http.dart';
 
-class HttpClient{
+class HttpClient {
   final http = Client();
 
-  Future<Response> get({required String authority, required String path, required Map<String, dynamic> param}){
-    return http.get(Uri.https(authority, path, param)).timeout(const Duration(seconds: 20));
+  Future<Response> get(
+      {required String authority,
+      required String path,
+      required Map<String, dynamic> param,
+      Map<String, String>? headers}) {
+    return http
+        .get(Uri.https(authority, path, param), headers: headers)
+        .timeout(const Duration(seconds: 20));
   }
 }

--- a/lib/src/data/data_sources/get_search_remote_datasource.dart
+++ b/lib/src/data/data_sources/get_search_remote_datasource.dart
@@ -6,6 +6,7 @@ import 'package:awesome_place_search/src/core/client/http_client.dart';
 import 'package:awesome_place_search/src/core/error/exceptions/key_empty_exception.dart';
 import 'package:awesome_place_search/src/data/data_sources/iget_search_remote_datasource.dart';
 import 'package:awesome_place_search/src/data/models/lat_lng_model.dart';
+import 'package:google_api_headers/google_api_headers.dart';
 
 import '../../core/error/exceptions/network_exception.dart';
 import '../../core/error/exceptions/server_exception.dart';
@@ -21,9 +22,12 @@ class GetSearchRemoteDataSource implements IGetSearchRemoteDataSource {
   final HttpClient http;
   final url = "maps.googleapis.com";
 
+  static const _googleApiHeaders = GoogleApiHeaders();
+
   @override
   Future<LatLngModel> getLatLng({required String param}) async {
     try {
+      final headers = await _googleApiHeaders.getHeaders();
       var res = await http.get(
         authority: url,
         path: "maps/api/place/details/json",
@@ -31,6 +35,7 @@ class GetSearchRemoteDataSource implements IGetSearchRemoteDataSource {
           "placeid": param,
           "key": key,
         },
+        headers: headers,
       );
       if (res.statusCode == 200) {
         final value = json.decode(res.body);
@@ -56,6 +61,7 @@ class GetSearchRemoteDataSource implements IGetSearchRemoteDataSource {
       throw InvalidKeyException();
     } else {
       try {
+        final headers = await _googleApiHeaders.getHeaders();
         var res = await http.get(
           authority: url,
           path: "maps/api/place/autocomplete/json",
@@ -65,6 +71,7 @@ class GetSearchRemoteDataSource implements IGetSearchRemoteDataSource {
             // "components": "country:ao|country:pt",
             "components": param.countries ?? "",
           },
+          headers: headers,
         );
         if (res.statusCode == 200) {
           final result = awesomePlacesModelFromJson(res.body);

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -57,6 +57,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
+  ffi:
+    dependency: transitive
+    description:
+      name: ffi
+      sha256: "16ed7b077ef01ad6170a3d0c57caa4a112a38d7a2ed5602e0aca9ca6f3d98da6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.3"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -75,6 +83,19 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_web_plugins:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
+  google_api_headers:
+    dependency: "direct main"
+    description:
+      name: google_api_headers
+      sha256: b823a8ddd1f76254f5ab7425d8dd562d25cf6c907ccbf0be45d0bf228b34e0f8
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.2.5"
   http:
     dependency: "direct main"
     description:
@@ -95,18 +116,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
+      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.4"
+    version: "10.0.5"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
+      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "3.0.5"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -135,18 +156,34 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.0"
+    version: "1.15.0"
+  package_info_plus:
+    dependency: transitive
+    description:
+      name: package_info_plus
+      sha256: da8d9ac8c4b1df253d1a328b7bf01ae77ef132833479ab40763334db13b91cce
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.1.1"
+  package_info_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: package_info_plus_platform_interface
+      sha256: ac1f4a4847f1ade8e6a87d1f39f5d7c67490738642e2542f559ec38c37489a66
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.1"
   path:
     dependency: transitive
     description:
@@ -155,6 +192,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.0"
+  plugin_platform_interface:
+    dependency: transitive
+    description:
+      name: plugin_platform_interface
+      sha256: "4820fbfdb9478b1ebae27888254d445073732dae3d6ea81f0b7e06d5dedc3f02"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.8"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -204,10 +249,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
+      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.0"
+    version: "0.7.2"
   typed_data:
     dependency: transitive
     description:
@@ -228,10 +273,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
+      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.1"
+    version: "14.2.5"
   web:
     dependency: transitive
     description:
@@ -240,6 +285,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.5.1"
+  win32:
+    dependency: transitive
+    description:
+      name: win32
+      sha256: "84ba388638ed7a8cb3445a320c8273136ab2631cd5f2c57888335504ddab1bc2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.8.0"
 sdks:
-  dart: ">=3.3.0 <4.0.0"
-  flutter: ">=3.18.0-18.0.pre.54"
+  dart: ">=3.5.4 <4.0.0"
+  flutter: ">=3.24.4"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,6 +11,7 @@ dependencies:
     sdk: flutter
   http: ^1.2.1
   dartz: ^0.10.1
+  google_api_headers: ^4.2.5
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Changes
- Added support for Google API headers in HTTP requests using the `google_api_headers` package
- Modified `HttpClient` to accept optional headers parameter
- Integrated Google API headers in `GetSearchRemoteDataSource` for both place details and autocomplete endpoints

## Why
When making requests to Google Maps APIs from Flutter applications, certain platform-specific headers are required for proper authentication and request tracking. The `google_api_headers` package automatically handles these requirements by providing the appropriate headers based on the platform (Android/iOS).

## Testing
- Verified that place search and details requests work correctly with the added headers
- Confirmed compatibility with both Android and iOS platforms

## Dependencies Added
- google_api_headers: ^4.2.5